### PR TITLE
fix vanilla lingering potion crash, main thread server hitching on join, ritual item duplication, and invalid physics vectors

### DIFF
--- a/src/main/java/io/github/mxiwbr/capturebiomes/CaptureBiomes.java
+++ b/src/main/java/io/github/mxiwbr/capturebiomes/CaptureBiomes.java
@@ -19,7 +19,7 @@ public final class CaptureBiomes extends JavaPlugin {
     public static Logger LOGGER;
     public static CaptureBiomes INSTANCE;
     public static Config CONFIG;
-    public static Boolean newVersionAvailable;
+    public static boolean newVersionAvailable = false;
 
     // Called when the plugin is enabled
     @Override

--- a/src/main/java/io/github/mxiwbr/capturebiomes/factories/ItemFactory.java
+++ b/src/main/java/io/github/mxiwbr/capturebiomes/factories/ItemFactory.java
@@ -33,6 +33,8 @@ public class ItemFactory {
      */
     public static ItemStack createBiomePotion(Biome biome, int tier) {
 
+        if (biome == null) { return null; }
+
         // Create potion ItemStack as lingering potion
         ItemStack potion = new ItemStack(Material.LINGERING_POTION);
         // create meta for the item

--- a/src/main/java/io/github/mxiwbr/capturebiomes/listener/EntityListener.java
+++ b/src/main/java/io/github/mxiwbr/capturebiomes/listener/EntityListener.java
@@ -11,6 +11,7 @@ import io.papermc.paper.registry.RegistryKey;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
+import org.bukkit.Color;
 import org.bukkit.NamespacedKey;
 import org.bukkit.World;
 import org.bukkit.entity.AreaEffectCloud;
@@ -49,29 +50,47 @@ public class EntityListener implements Listener {
         // The areaEffectCloud that was spawned by splashing the potion
         AreaEffectCloud areaEffectCloud = event.getAreaEffectCloud();
 
-        PersistentDataContainer pdc = potionItem.getItemMeta().getPersistentDataContainer();
+        if (potionItem == null || !potionItem.hasItemMeta()) { return; }
 
+        PersistentDataContainer pdc = potionItem.getItemMeta().getPersistentDataContainer();
         NamespacedKey key = new NamespacedKey(CaptureBiomes.INSTANCE, "capturebiomes.biomepotion");
 
-        // Get the biome from pdt key "capturebiomes.biomepotion.biome"
-        var biomeKey = pdc.get(new NamespacedKey(CaptureBiomes.INSTANCE, "capturebiomes.biomepotion.biome"), PersistentDataType.STRING);
-        var biomes = RegistryAccess.registryAccess().getRegistry(RegistryKey.BIOME);
-        var biome = biomes.get(NamespacedKey.fromString(biomeKey));
+        // Cancel if not biome potion (key capturebiomes.biomepotion)
+        if (!pdc.has(key, PersistentDataType.INTEGER)) { return; }
+
+        // the tier (level) of the potion (1 - 4)
+        final Integer tier = pdc.get(key, PersistentDataType.INTEGER);
+        if (tier == null) { return; }
 
         // Cancel and delete areaEffectCloud if not in overworld
-        if (world.getEnvironment() != World.Environment.NORMAL) {
+        if (world == null || world.getEnvironment() != World.Environment.NORMAL) {
 
-            log("Creation of biome at " + potionEntity.getLocation().getWorld() + " failed: the biome / dimension is either not supported or could not be found.", ConsoleUtils.LogType.WARNING);
+            log("Creation of biome at " + (world != null ? world.getName() : "unknown") + " failed: the biome / dimension is either not supported or could not be found.", ConsoleUtils.LogType.WARNING);
             log("If you think that this is a bug, please create an issue: https://github.com/mxiwbr/capture-bioms/issues", ConsoleUtils.LogType.WARNING);
             areaEffectCloud.remove();
             return;
         }
 
-        // Cancel if not biome potion (key capturebiomes.biomepotion)
-        if (!pdc.has(key)) { return; }
+        // Get the biome from pdt key "capturebiomes.biomepotion.biome"
+        var biomeKey = pdc.get(new NamespacedKey(CaptureBiomes.INSTANCE, "capturebiomes.biomepotion.biome"), PersistentDataType.STRING);
+        if (biomeKey == null) {
+            areaEffectCloud.remove();
+            return;
+        }
 
-        // the tier (level) of the potion (1 - 4)
-        final int tier = pdc.get(key, PersistentDataType.INTEGER);
+        NamespacedKey namespacedKey = NamespacedKey.fromString(biomeKey);
+        if (namespacedKey == null) {
+            areaEffectCloud.remove();
+            return;
+        }
+
+        var biomes = RegistryAccess.registryAccess().getRegistry(RegistryKey.BIOME);
+        var biome = biomes.get(namespacedKey);
+        if (biome == null) {
+            areaEffectCloud.remove();
+            return;
+        }
+
         areaEffectCloud.setRadius(0);
 
         final int maxHeight = world.getMaxHeight();
@@ -88,9 +107,17 @@ public class EntityListener implements Listener {
                 size,
                 Math.min(nextBlockY + (CONFIG.getBiomePotionYOffsetMultiplier() * size), maxHeight));
 
+        Color particleColor = BiomeUtils.getBiomeColor(biomeKey);
+        if (particleColor == null && potionEntity.getPotionMeta() != null && potionEntity.getPotionMeta().getColor() != null) {
+            particleColor = potionEntity.getPotionMeta().getColor();
+        }
+        if (particleColor == null) {
+            particleColor = Color.WHITE;
+        }
+
         // particle effect up to max world height or next block on y coordinate above the block
         ParticleFactory.createSquareRisingEdges(potionEntity.getLocation(),
-                potionEntity.getPotionMeta().getColor(),
+                particleColor,
                 size,
                 Math.min(nextBlockY + (CONFIG.getBiomePotionYOffsetMultiplier() * size), maxHeight));
 
@@ -100,7 +127,7 @@ public class EntityListener implements Listener {
         // Refresh affected chunks for players to see the biome change instantly
         BlockUtils.refreshChunksFromBoundingBox(boundingBox, world);
 
-        log("A biome of type " + biome.getKey().getKey() + " with size " + CONFIG.getBiomePotionSize()[tier - 1] + " x " + CONFIG.getBiomePotionSize()[tier - 1] + " was created at center " + potionEntity.getLocation(), ConsoleUtils.LogType.ADDITIONAL_INFO);
+        log("A biome of type " + biome.getKey().getKey() + " with size " + size + " x " + size + " was created at center " + potionEntity.getLocation(), ConsoleUtils.LogType.ADDITIONAL_INFO);
 
     }
 

--- a/src/main/java/io/github/mxiwbr/capturebiomes/registries/CommandRegistry.java
+++ b/src/main/java/io/github/mxiwbr/capturebiomes/registries/CommandRegistry.java
@@ -83,10 +83,16 @@ public class CommandRegistry {
                                         return 0;
                                     }
 
-                                    CommandActions.commandGivebiomepotion(RegistryAccess
-                                            .registryAccess()
-                                            .getRegistry(RegistryKey.BIOME)
-                                            .get(NamespacedKey.fromString(biomeName)), IntegerArgumentType.getInteger(ctx, "tier"), player);
+                                    NamespacedKey biomeNamespacedKey = NamespacedKey.fromString(biomeName);
+                                    var biomeRegistry = RegistryAccess.registryAccess().getRegistry(RegistryKey.BIOME);
+                                    Biome biome = biomeNamespacedKey != null ? biomeRegistry.get(biomeNamespacedKey) : null;
+
+                                    if (biome == null) {
+                                        player.sendMessage(Component.text("Biome '" + biomeName + "' could not be found in the registry!", NamedTextColor.RED));
+                                        return 0;
+                                    }
+
+                                    CommandActions.commandGivebiomepotion(biome, IntegerArgumentType.getInteger(ctx, "tier"), player);
 
                                     return 1;
 

--- a/src/main/java/io/github/mxiwbr/capturebiomes/services/BeaconRitualService.java
+++ b/src/main/java/io/github/mxiwbr/capturebiomes/services/BeaconRitualService.java
@@ -67,10 +67,14 @@ public class BeaconRitualService {
 
             if (!(entity instanceof Item itemEntity)) continue;
 
-            Vector direction = center.toVector()
-                    .subtract(itemEntity.getLocation().toVector())
-                    .normalize();
+            Vector direction = itemEntity.getLocation().toVector()
+                    .subtract(center.toVector());
 
+            if (direction.lengthSquared() < 1e-6) {
+                direction = new Vector(Math.random() - 0.5, 0, Math.random() - 0.5);
+            }
+
+            direction.normalize();
             direction.multiply(0.7);
             direction.setY(0.6);
 

--- a/src/main/java/io/github/mxiwbr/capturebiomes/services/UpdateService.java
+++ b/src/main/java/io/github/mxiwbr/capturebiomes/services/UpdateService.java
@@ -20,6 +20,8 @@ import static io.github.mxiwbr.capturebiomes.utils.ConsoleUtils.log;
 
 public class UpdateService {
 
+    private static String cachedLatestVersion;
+
     /**
      * Scans the GitHub page for new releases
      * @return true or false whether a new update is available
@@ -33,6 +35,7 @@ public class UpdateService {
         try {
 
             String latestPluginVersion = getLatestVersion();
+            cachedLatestVersion = latestPluginVersion;
 
             // Check if new version is available and log it
             if (!pluginVersion.equals(latestPluginVersion)) {
@@ -70,10 +73,21 @@ public class UpdateService {
         HttpResponse<String> httpResponse = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
         httpClient.close();
 
-        String jsonString = httpResponse.body();
-        JsonArray jsonObject = JsonParser.parseString(jsonString).getAsJsonArray();
+        if (httpResponse.statusCode() != 200) {
+            throw new IOException("Modrinth API returned status code: " + httpResponse.statusCode());
+        }
 
-        JsonObject latestVersion = jsonObject.get(0).getAsJsonObject();
+        String jsonString = httpResponse.body();
+        var jsonElement = JsonParser.parseString(jsonString);
+        if (!jsonElement.isJsonArray()) {
+            throw new IOException("Modrinth API response is not a JSON array");
+        }
+        JsonArray jsonArray = jsonElement.getAsJsonArray();
+        if (jsonArray.isEmpty()) {
+            throw new IOException("Modrinth API returned an empty version array");
+        }
+
+        JsonObject latestVersion = jsonArray.get(0).getAsJsonObject();
 
         return latestVersion.get("version_number").getAsString();
 
@@ -87,9 +101,11 @@ public class UpdateService {
 
         try {
 
+            String version = cachedLatestVersion != null ? cachedLatestVersion : getLatestVersion();
+
             player.sendMessage(Component.text("[CaptureBiomes] ", NamedTextColor.GREEN, TextDecoration.BOLD)
                     .append(Component.text("There is a newer plugin version available: "
-                                    + UpdateService.getLatestVersion()
+                                    + version
                                     + ", you're on: "
                                     + CaptureBiomes.INSTANCE.getPluginMeta().getVersion(), NamedTextColor.GREEN)
                             .decorationIfAbsent(TextDecoration.BOLD, TextDecoration.State.FALSE)));

--- a/src/main/java/io/github/mxiwbr/capturebiomes/utils/BiomeUtils.java
+++ b/src/main/java/io/github/mxiwbr/capturebiomes/utils/BiomeUtils.java
@@ -79,11 +79,22 @@ public class BiomeUtils {
      */
     public static void fillBiome(World world, BoundingBox box, Biome biome) {
 
-        for (int x = (int) box.getMinX(); x <= box.getMaxX(); x++) {
+        if (world == null || box == null || biome == null) {
+            return;
+        }
 
-            for (int z = (int) box.getMinZ(); z <= box.getMaxZ(); z++) {
+        int minX = (int) Math.floor(box.getMinX());
+        int maxX = (int) Math.floor(box.getMaxX());
+        int minZ = (int) Math.floor(box.getMinZ());
+        int maxZ = (int) Math.floor(box.getMaxZ());
+        int minY = Math.max((int) Math.floor(box.getMinY()), world.getMinHeight());
+        int maxY = Math.min((int) Math.floor(box.getMaxY()), world.getMaxHeight() - 1);
 
-                for (int y = (int) box.getMinY(); y <= box.getMaxY(); y++) {
+        for (int x = minX; x <= maxX; x++) {
+
+            for (int z = minZ; z <= maxZ; z++) {
+
+                for (int y = minY; y <= maxY; y++) {
 
                     world.setBiome(x, y, z, biome);
 

--- a/src/main/java/io/github/mxiwbr/capturebiomes/utils/ItemUtils.java
+++ b/src/main/java/io/github/mxiwbr/capturebiomes/utils/ItemUtils.java
@@ -20,8 +20,9 @@ public class ItemUtils {
         if (itemStack.getAmount() > amount) {
 
             itemStack.setAmount(itemStack.getAmount() - amount);
+            item.setItemStack(itemStack);
         }
-        else if (itemStack.getAmount() == amount) {
+        else if (itemStack.getAmount() <= amount) {
 
             item.remove();
         }


### PR DESCRIPTION
- **Prevented hard crashes and cloud deletion on vanilla lingering potions (`EntityListener.java`):**
  - *What:* Moved the `PersistentDataContainer` biome key verification to the very top of `onLingeringPotionSplash`, added null guards for item meta and registry resolution, and relocated the dimension check (`World.Environment.NORMAL`) after confirming the potion is a custom biome potion.
  - *Why:* `onLingeringPotionSplash` listens to all lingering potion splashes across the server. For regular vanilla potions (e.g., healing, poison, invisibility), `pdc.get(..., "biome")` evaluates to `null`. The previous implementation immediately executed `NamespacedKey.fromString(null)`, throwing an uncaught `IllegalArgumentException` on the main server thread. Furthermore, checking the dimension before verifying the PDC caused vanilla lingering potions splashed in the Nether or The End to have their `AreaEffectCloud` unconditionally removed (`areaEffectCloud.remove()`).

- **Eliminated main thread blocking HTTP requests during player logins (`UpdateService.java`, `CaptureBiomes.java`):**
  - *What:* Cached the latest version string retrieved during startup in `UpdateService`, utilized this cached version inside `sendUpdateMessageToPlayer()`, changed `newVersionAvailable` from a boxed `Boolean` to a primitive `boolean`, and added HTTP status and JSON array checks in `getLatestVersion()`.
  - *Why:* In `PlayerJoinEvent`, whenever an operator joined the server, `sendUpdateMessageToPlayer()` invoked `getLatestVersion()`, which executed a synchronous `HttpClient.send()` call directly on the main server thread. This stalled server ticking while waiting for the Modrinth API response. Caching the version string resolves the notification instantly without network latency. Replacing boxed `Boolean` with primitive `boolean` eliminates unboxing NPE hazards during login.

- **Fixed beacon ritual item boost direction and `NaN` velocity corruption (`BeaconRitualService.java`):**
  - *What:* Corrected the displacement vector from `center.toVector().subtract(itemEntity.getLocation().toVector())` to `itemEntity.getLocation().toVector().subtract(center.toVector())`, and added a fallback non-zero dispersion vector when length is near zero.
  - *Why:* The previous vector calculation produced a vector pointing toward `center`, pulling nearby items inward toward the beacon rather than scattering them outward. Additionally, when XP bottles were placed exactly at the beacon's center coordinate, `subtract()` returned `(0, 0, 0)`. Calling `.normalize()` on a zero-length vector performed division by zero (`0.0 / 0.0`), producing `(NaN, NaN, NaN)` velocities. Applying `NaN` velocities corrupts entity physics calculations and can crash entity ticking in the server engine.

- **Resolved ritual item duplication bug (`ItemUtils.java`):**
  - *What:* Added `item.setItemStack(itemStack)` after modifying the stack amount in `removeItemsFromStack()`.
  - *Why:* In the Bukkit/Paper API, `item.getItemStack()` returns a copy/snapshot of the dropped item entity's stack. Calling `itemStack.setAmount(...)` only mutated the local object reference and did not persist the reduced count back to the `Item` entity. As a result, the XP bottle stack on the ground was never consumed, allowing players to trigger infinite beacon rituals with a single stack.

- **Enforced world height boundaries during biome fill operations (`BiomeUtils.java`):**
  - *What:* Clamped the vertical iteration bounds in `fillBiome()` to `[world.getMinHeight(), world.getMaxHeight() - 1]` and replaced primitive double-to-int casts on bounding box min/max coordinates with `Math.floor()`.
  - *Why:* `BlockUtils.getBoundingBox()` calculates `minY` as `center.getY() - (multiplier * size)`. When a potion is splashed deep underground (e.g., Y = -55 with size 32), `minY` can evaluate to -87, which is below the Overworld minimum height (-64). Passing out-of-bounds Y coordinates into `world.setBiome()` throws runtime exceptions or corrupts chunk section indexes. Direct `(int)` casts also truncate negative coordinates toward zero rather than rounding down, causing off-by-one boundary inaccuracies in negative chunk coordinates.

- **Added null safety checks for biome registry lookups (`ItemFactory.java`, `CommandRegistry.java`):**
  - *What:* Added a null guard for the `Biome` parameter in `ItemFactory.createBiomePotion()` and validated the registry lookup result before invoking `commandGivebiomepotion` in `CommandRegistry`.
  - *Why:* If an operator executed `/capturebiomes givebiomepotion` with a biome name supported by the color switch table in `BiomeUtils` but missing from the active server registry, `biomes.get(...)` returned `null`. Passing `null` to `createBiomePotion()` caused a `NullPointerException` when dereferencing `biome.getKey()`.